### PR TITLE
Fix warlock HP RPN and green spawns not being green

### DIFF
--- a/Assets/Resources/levels.json
+++ b/Assets/Resources/levels.json
@@ -1,5 +1,5 @@
 [
-   {   
+   {
        "name": "Easy",
        "waves": 10,
        "spawns": [
@@ -11,7 +11,7 @@
                 "sequence": [1,2,3],
                 "location": "random"
             },
-            {   
+            {
                 "enemy": "skeleton",
                 "count": "wave 3 /",
                 "hp": "30 wave *",
@@ -21,12 +21,12 @@
             {
                 "enemy": "warlock",
                 "count": "wave 5 / 1 wave 5 % - *",
-                "hp": "100 25 wave *",
+                "hp": "100 25 wave * +",
                 "location": "random bone"
-            }       
+            }
         ]
    },
-   {   
+   {
        "name": "Medium",
        "waves": 15,
        "spawns": [
@@ -38,7 +38,7 @@
                 "sequence": [1,2,3],
                 "location": "random"
             },
-            {   
+            {
                 "enemy": "skeleton",
                 "count": "wave 2 /",
                 "hp": "25 wave *",
@@ -48,13 +48,13 @@
             {
                 "enemy": "warlock",
                 "count": "wave 5 / 1 wave 5 % - *",
-                "hp": "75 50 wave *",
+                "hp": "75 50 wave * +",
                 "damage": "base 10 +",
                 "location": "random bone"
-            }       
+            }
         ]
    },
-   {   
+   {
        "name": "Endless",
        "spawns": [
             {
@@ -65,7 +65,7 @@
                 "sequence": [1,2,3],
                 "location": "random"
             },
-            {   
+            {
                 "enemy": "skeleton",
                 "count": "wave 4 /",
                 "hp": "20 wave *",
@@ -75,10 +75,10 @@
             {
                 "enemy": "warlock",
                 "count": "wave 10 / 1 wave 10 % - *",
-                "hp": "75 15 wave *",
+                "hp": "75 15 wave * +",
                 "damage": "base 5 -",
                 "location": "random bone"
-            }       
+            }
         ]
    }
 ]

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -3123,7 +3123,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa898092d9b0d8a41b153c7d66e057a4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  kind: 0
+  kind: 1
 --- !u!1 &967867791
 GameObject:
   m_ObjectHideFlags: 0
@@ -4172,7 +4172,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa898092d9b0d8a41b153c7d66e057a4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  kind: 0
+  kind: 1
 --- !u!1 &1468482022
 GameObject:
   m_ObjectHideFlags: 0
@@ -4894,7 +4894,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa898092d9b0d8a41b153c7d66e057a4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  kind: 0
+  kind: 1
 --- !u!1 &1707093149
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This PR fixes the RPN for the HP of warlock on all difficulties and green spawns being marked as `RED` instead of `GREEN`. It's pretty late, but I'm making this PR because I'm surprised no one else did.