### PR TITLE
Reordered battlemage attributes to match the other classes

### DIFF
--- a/Assets/Resources/classes.json
+++ b/Assets/Resources/classes.json
@@ -18,8 +18,8 @@
     "battlemage": {
             "sprite": 2,
             "health": "90 wave 15 * +",
+			"mana": "120",
             "mana_regeneration": "15",
-            "mana": "120",
             "spellpower": "wave 5 *",
             "speed": "5 wave 2 / +"
     }


### PR DESCRIPTION
The other classes had `sprite`, `health`, `mana`, `mana_regeneration`, `spellpower`, and `speed` in that order. Battlemage had `mana` and `mana_regeneration` swapped. I fixed the order to match the other classes in `Resources/classes.json`.